### PR TITLE
[Dogs][Data/Domain] Refactor DogsRepository to map API models to domain and improve encapsulation

### DIFF
--- a/Chiefapp/Features/Dogs/Data/DogsRepository.swift
+++ b/Chiefapp/Features/Dogs/Data/DogsRepository.swift
@@ -1,18 +1,17 @@
 import Foundation
 
 protocol DogsRepositoryProtocol {
-  var dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol { get }
-  func fetchDogs() async throws -> [DogApiResponse]
+  func fetchDogs() async throws -> [Dog]
 }
 
 struct DogsRepository: DogsRepositoryProtocol {
-  var dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol
-  
+  private let dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol
+
   init(dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol) {
     self.dogsRemoteDataSourceProtocol = dogsRemoteDataSourceProtocol
   }
   
-  func fetchDogs() async throws -> [DogApiResponse] {
-    try await dogsRemoteDataSourceProtocol.fetchDogs()
+  func fetchDogs() async throws -> [Dog] {
+    try await dogsRemoteDataSourceProtocol.fetchDogs().toDogList()
   }
 }

--- a/Chiefapp/Features/Dogs/Data/Remote/DogApiModel.swift
+++ b/Chiefapp/Features/Dogs/Data/Remote/DogApiModel.swift
@@ -6,3 +6,20 @@ struct DogApiResponse: Decodable {
   let age: Int?
   let image: String?
 }
+
+extension DogApiResponse {
+
+  func toDog() -> Dog {
+    Dog(name: dogName ?? "",
+        description: description ?? "",
+        age: age ?? 0,
+        imageUrl: image ?? "")
+  }
+}
+
+extension Array where Element == DogApiResponse {
+
+  func toDogList() -> [Dog] {
+    self.map { $0.toDog() }
+  }
+}

--- a/Chiefapp/Features/Dogs/Data/Remote/DogsRemoteDataSource.swift
+++ b/Chiefapp/Features/Dogs/Data/Remote/DogsRemoteDataSource.swift
@@ -1,19 +1,17 @@
 import Foundation
 
 protocol DogsRemoteDataSourceProtocol {
-  var  apiClient: APIClientProtocol { get }
   func fetchDogs() async throws -> [DogApiResponse]
 }
 
 struct DogsRemoteDataSource: DogsRemoteDataSourceProtocol {
-  var apiClient: APIClientProtocol
-  
+  private let apiClient: APIClientProtocol
+
   init(apiClient: APIClientProtocol) {
     self.apiClient = apiClient
   }
-  
+
   func fetchDogs() async throws -> [DogApiResponse] {
-    let response: [DogApiResponse] = try await apiClient.get(path: APIConfig.Endpoint.allDogs)
-    return response
+    try await apiClient.get(path: APIConfig.Endpoint.allDogs)
   }
 }

--- a/Chiefapp/Features/Dogs/Domain/DogModel.swift
+++ b/Chiefapp/Features/Dogs/Domain/DogModel.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Dog {
+  let name: String
+  let description: String
+  let age: Int
+  let imageUrl: String
+}

--- a/Chiefapp/Features/Dogs/Domain/GetDogsUseCase.swift
+++ b/Chiefapp/Features/Dogs/Domain/GetDogsUseCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol GetDogsUseCaseProtocol {
+  func fetchDogs() async -> Result<[Dog], Error>
+}
+
+struct GetDogsUseCase: GetDogsUseCaseProtocol {
+  private let dogsRepositoryProtocol: DogsRepositoryProtocol
+
+  init(dogsRepositoryProtocol: DogsRepositoryProtocol) {
+    self.dogsRepositoryProtocol = dogsRepositoryProtocol
+  }
+
+  func fetchDogs() async -> Result<[Dog], Error> {
+    do {
+      let dogs = try await dogsRepositoryProtocol.fetchDogs()
+      return .success(dogs)
+    } catch {
+      return .failure(error)
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Refactored DogsRepository to map DogApiResponse to Dog using a new extension, ensuring a clear separation between data and domain layers. Also made the remote data source property private.

Changes:

1. Updated fetchDogs() to return [Dog] via .toDogList().
2. Encapsulated dogsRemoteDataSourceProtocol as a private property.
3. Added mapping extension in DogApiModel.swift.

Benefits:

- Enforces Clean Architecture boundaries.
- Improves encapsulation and readability.
- Prepares codebase for future testability and scaling.