### PR TITLE
[Core/Database] Integrate Core Data with DogEntity Model

### DIFF
--- a/Chiefapp.xcodeproj/project.pbxproj
+++ b/Chiefapp.xcodeproj/project.pbxproj
@@ -6,8 +6,15 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		20332CC12E0734F600F42910 /* DogEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20332CBF2E0734F600F42910 /* DogEntity+CoreDataClass.swift */; };
+		20332CC22E0734F600F42910 /* DogEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20332CC02E0734F600F42910 /* DogEntity+CoreDataProperties.swift */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		2006A0652E062F6000382AD7 /* Chiefapp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chiefapp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		20332CBF2E0734F600F42910 /* DogEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "DogEntity+CoreDataClass.swift"; path = "Chiefapp/Core/Database/DogEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		20332CC02E0734F600F42910 /* DogEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "DogEntity+CoreDataProperties.swift"; path = "Chiefapp/Core/Database/DogEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -32,6 +39,8 @@
 		2006A05C2E062F6000382AD7 = {
 			isa = PBXGroup;
 			children = (
+				20332CBF2E0734F600F42910 /* DogEntity+CoreDataClass.swift */,
+				20332CC02E0734F600F42910 /* DogEntity+CoreDataProperties.swift */,
 				2006A0672E062F6000382AD7 /* Chiefapp */,
 				2006A0662E062F6000382AD7 /* Products */,
 			);
@@ -119,6 +128,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20332CC12E0734F600F42910 /* DogEntity+CoreDataClass.swift in Sources */,
+				20332CC22E0734F600F42910 /* DogEntity+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Chiefapp/Core/Database/ChiefModel.xcdatamodeld/ChiefModel.xcdatamodel/contents
+++ b/Chiefapp/Core/Database/ChiefModel.xcdatamodeld/ChiefModel.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="DogEntity" representedClassName=".DogEntity" syncable="YES">
+        <attribute name="age" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dogDescription" optional="YES" attributeType="String"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/Chiefapp/Core/Database/CoreDataStack.swift
+++ b/Chiefapp/Core/Database/CoreDataStack.swift
@@ -1,0 +1,32 @@
+import CoreData
+
+final class CoreDataStack {
+  static let shared = CoreDataStack()
+
+  private init() {}
+
+  var container: NSPersistentContainer = {
+    let container = NSPersistentContainer(name: "ChiefModel")
+    container.loadPersistentStores { _, error in
+      if let error = error {
+        fatalError("Core Data load error: \(error)")
+      }
+    }
+    return container
+  }()
+
+  var context: NSManagedObjectContext {
+    container.viewContext
+  }
+  
+  func saveContext() {
+    let context = container.viewContext
+    if context.hasChanges {
+      do {
+        try context.save()
+      } catch {
+        print("Error saving context: \(error.localizedDescription)")
+      }
+    }
+  }
+}

--- a/Chiefapp/Core/Database/DogEntity+CoreDataClass.swift
+++ b/Chiefapp/Core/Database/DogEntity+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+
+public class DogEntity: NSManagedObject {
+
+}

--- a/Chiefapp/Core/Database/DogEntity+CoreDataProperties.swift
+++ b/Chiefapp/Core/Database/DogEntity+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+
+extension DogEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DogEntity> {
+        return NSFetchRequest<DogEntity>(entityName: "DogEntity")
+    }
+
+    @NSManaged public var age: Int16
+    @NSManaged public var dogDescription: String?
+    @NSManaged public var imageUrl: String?
+    @NSManaged public var name: String?
+
+}
+
+extension DogEntity : Identifiable {
+
+}


### PR DESCRIPTION
📝 Description

This PR introduces initial Core Data integration into the project with the following changes:

1. Added a ChiefModel.xcdatamodeld file defining the DogEntity with attributes: name, age, dogDescription, and imageUrl.
2. Generated DogEntity+CoreDataClass.swift and DogEntity+CoreDataProperties.swift files.
3. Created a reusable CoreDataStack singleton to manage the NSPersistentContainer and context.
4. Registered all new Core Data files in the Xcode project structure and build phases.