### PR TITLE
[Core/Data] Integrate local data caching with Core Data for dogs module

### DIFF
--- a/Chiefapp/Core/DI/ChiefInjector.swift
+++ b/Chiefapp/Core/DI/ChiefInjector.swift
@@ -1,7 +1,11 @@
 import Foundation
+import CoreData
 import SwiftUI
 
 enum ChiefInjector {
+  private static func provideCoreDataContext() -> NSManagedObjectContext {
+    CoreDataStack.shared.context
+  }
 
   private static func provideAPIClient() -> APIClientProtocol {
     APIClient(
@@ -15,8 +19,15 @@ enum ChiefInjector {
     DogsRemoteDataSource(apiClient: provideAPIClient())
   }
 
+  private static func provideDogsLocalDataSource() -> DogsLocalDataSourceProtocol {
+    DogsLocalDataSource(managedContext: provideCoreDataContext())
+  }
+
   private static func provideDogsRepository() -> DogsRepositoryProtocol {
-    DogsRepository(dogsRemoteDataSourceProtocol: provideDogsRemoteDataSource())
+    DogsRepository(
+      dogsRemoteDataSourceProtocol: provideDogsRemoteDataSource(),
+      dogsLocalDataSourceProtocol: provideDogsLocalDataSource()
+    )
   }
 
   private static func provideGetDogsUseCase() -> GetDogsUseCaseProtocol {

--- a/Chiefapp/Features/Dogs/Data/DogsRepository.swift
+++ b/Chiefapp/Features/Dogs/Data/DogsRepository.swift
@@ -1,17 +1,37 @@
 import Foundation
 
 protocol DogsRepositoryProtocol {
-  func fetchDogs() async throws -> [Dog]
+  func fetchDogs() async -> Result<[Dog], Error>
 }
 
 struct DogsRepository: DogsRepositoryProtocol {
   private let dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol
-
-  init(dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol) {
+  private let dogslocalDataSourceProtocol: DogsLocalDataSourceProtocol
+  
+  init(
+    dogsRemoteDataSourceProtocol: DogsRemoteDataSourceProtocol,
+    dogsLocalDataSourceProtocol: DogsLocalDataSourceProtocol
+  ) {
     self.dogsRemoteDataSourceProtocol = dogsRemoteDataSourceProtocol
+    self.dogslocalDataSourceProtocol = dogsLocalDataSourceProtocol
   }
   
   func fetchDogs() async throws -> [Dog] {
     try await dogsRemoteDataSourceProtocol.fetchDogs().toDogList()
+  }
+  
+  func fetchDogs() async -> Result<[Dog], any Error> {
+    do {
+      let remoteDogs = try await dogsRemoteDataSourceProtocol.fetchDogs().toDogList()
+      try await dogslocalDataSourceProtocol.saveDogs(remoteDogs)
+      return .success(remoteDogs)
+    } catch {
+      do {
+        let localDogs = try await dogslocalDataSourceProtocol.fetchDogs()
+        return .success(localDogs)
+      } catch {
+        return .failure(error)
+      }
+    }
   }
 }

--- a/Chiefapp/Features/Dogs/Data/Local/DogsLocalDataSource.swift
+++ b/Chiefapp/Features/Dogs/Data/Local/DogsLocalDataSource.swift
@@ -1,0 +1,66 @@
+import Foundation
+import CoreData
+
+protocol DogsLocalDataSourceProtocol {
+  func saveDogs(_ dogs: [Dog]) async throws
+  func fetchDogs() async throws -> [Dog]
+  func clearDogs() async throws
+}
+
+struct DogsLocalDataSource: DogsLocalDataSourceProtocol {
+  private let managedContext: NSManagedObjectContext
+
+  init(managedContext: NSManagedObjectContext) {
+    self.managedContext = managedContext
+  }
+
+  func saveDogs(_ dogs: [Dog]) async throws {
+    try await managedContext.perform {
+      try clearDogsSync()
+
+      for dog in dogs {
+        let entity = DogEntity(context: managedContext)
+        entity.name = dog.name
+        entity.dogDescription = dog.description
+        entity.age = Int16(dog.age)
+        entity.imageUrl = dog.imageUrl
+      }
+
+      try saveContextIfNeeded()
+    }
+  }
+
+  func fetchDogs() async throws -> [Dog] {
+    try await managedContext.perform {
+      let request: NSFetchRequest<DogEntity> = DogEntity.fetchRequest()
+      let result = try managedContext.fetch(request)
+
+      return result.map {
+        Dog(
+          name: $0.name ?? "",
+          description: $0.dogDescription ?? "",
+          age: Int($0.age),
+          imageUrl: $0.imageUrl ?? ""
+        )
+      }
+    }
+  }
+
+  func clearDogs() async throws {
+    try await managedContext.perform {
+      try clearDogsSync()
+    }
+  }
+
+  private func clearDogsSync() throws {
+    let request: NSFetchRequest<NSFetchRequestResult> = DogEntity.fetchRequest()
+    let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+    try managedContext.execute(deleteRequest)
+  }
+
+  private func saveContextIfNeeded() throws {
+    if managedContext.hasChanges {
+      try managedContext.save()
+    }
+  }
+}

--- a/Chiefapp/Features/Dogs/Domain/GetDogsUseCase.swift
+++ b/Chiefapp/Features/Dogs/Domain/GetDogsUseCase.swift
@@ -12,11 +12,6 @@ struct GetDogsUseCase: GetDogsUseCaseProtocol {
   }
 
   func fetchDogs() async -> Result<[Dog], Error> {
-    do {
-      let dogs = try await dogsRepositoryProtocol.fetchDogs()
-      return .success(dogs)
-    } catch {
-      return .failure(error)
-    }
+    await dogsRepositoryProtocol.fetchDogs()
   }
 }


### PR DESCRIPTION
This PR introduces local data persistence using Core Data for the Dogs module. Key updates include:

- Added `DogsLocalDataSource` with async/await support for saving, fetching, and clearing dogs locally.
- Updated `DogsRepository` to:
  - Fetch data from remote and cache it locally on success.
  - Fallback to previously cached local data if remote fetch fails.
- Injected `DogsLocalDataSource` via `ChiefInjector`.
- Updated `GetDogsUseCase` to reflect the new repository implementation.